### PR TITLE
Updated requirements for Debian 9.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pre-compiled releases are [available](https://github.com/inversepath/usbarmory-d
 A Debian 9 installation with the following packages:
 
 ```
-bc binfmt-support bzip2 fakeroot gcc gcc-arm-linux-gnueabihf git gnupg make parted qemu-user-static wget xz-utils zip debootstrap sudo dirmngr
+bc binfmt-support bzip2 fakeroot gcc gcc-arm-linux-gnueabihf git gnupg make parted qemu-user-static wget xz-utils zip debootstrap sudo dirmngr bison flex
 ```
 
 Import the Linux signing GPG key:


### PR DESCRIPTION
Flex and bison were not present in Debian 9.6.