### PR TITLE
Add kmod as debian dependency needed for depmod

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Pre-compiled releases are [available](https://github.com/inversepath/usbarmory-d
 A Debian 9 installation with the following packages:
 
 ```
-bc binfmt-support bzip2 fakeroot gcc gcc-arm-linux-gnueabihf git gnupg make parted qemu-user-static wget xz-utils zip debootstrap sudo dirmngr bison flex libssl-dev
+bc binfmt-support bzip2 fakeroot gcc gcc-arm-linux-gnueabihf git gnupg make parted qemu-user-static wget xz-utils zip debootstrap sudo dirmngr bison flex libssl-dev kmod
 ```
 
 Import the Linux signing GPG key:


### PR DESCRIPTION
If kmod package is missing, you get following warnings:

  INSTALL security/keys/encrypted-keys/encrypted-keys.ko
  DEPMOD  4.19.67-0
Warning: 'make modules_install' requires /sbin/depmod. Please install it.
This is probably in the kmod package.
make[1]: Leaving directory '/data/usbarmory-debian-base_image/linux-4.19.67'