### PR TITLE
Fix building process to be able to continue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,19 +143,19 @@ u-boot-${UBOOT_VER}/u-boot-dtb.imx: check_version u-boot-${UBOOT_VER}.tar.bz2
 mxc-scc2-master.zip: check_version
 	@if test "${IMX}" = "imx53"; then \
 		wget ${MXC_SCC2_REPO}/archive/master.zip -O mxc-scc2-master.zip && \
-		unzip mxc-scc2-master; \
+		unzip -o mxc-scc2-master; \
 	fi
 
 mxs-dcp-longterm.zip: check_version
 	@if test "${IMX}" = "imx6ull"; then \
 		wget ${MXS_DCP_REPO}/archive/longterm.zip -O mxs-dcp-longterm.zip && \
-		unzip mxs-dcp-longterm; \
+		unzip -o mxs-dcp-longterm; \
 	fi
 
 caam-keyblob-master.zip: check_version
 	@if test "${IMX}" = "imx6ul"; then \
 		wget ${CAAM_KEYBLOB_REPO}/archive/master.zip -O caam-keyblob-master.zip && \
-		unzip caam-keyblob-master; \
+		unzip -o caam-keyblob-master; \
 	fi
 
 linux: linux-${LINUX_VER}/arch/arm/boot/zImage
@@ -216,8 +216,8 @@ linux-deb: check_version linux extra-dtb mxc-scc2 mxs-dcp caam-keyblob
 	@if test "${IMX}" = "imx6ul"; then \
 		cd caam-keyblob-master && make INSTALL_MOD_PATH=../linux-image-${LINUX_VER_MAJOR}-usbarmory-${V}_${LINUX_VER}${LOCALVERSION}_armhf ARCH=arm KERNEL_SRC=../linux-${LINUX_VER} modules_install; \
 	fi
-	cd linux-image-${LINUX_VER_MAJOR}-usbarmory-${V}_${LINUX_VER}${LOCALVERSION}_armhf/boot ; ln -s zImage-${LINUX_VER}${LOCALVERSION}-usbarmory zImage
-	cd linux-image-${LINUX_VER_MAJOR}-usbarmory-${V}_${LINUX_VER}${LOCALVERSION}_armhf/boot ; ln -s ${IMX}-usbarmory-default-${LINUX_VER}${LOCALVERSION}.dtb ${IMX}-usbarmory.dtb
+	cd linux-image-${LINUX_VER_MAJOR}-usbarmory-${V}_${LINUX_VER}${LOCALVERSION}_armhf/boot ; ln -sf zImage-${LINUX_VER}${LOCALVERSION}-usbarmory zImage
+	cd linux-image-${LINUX_VER_MAJOR}-usbarmory-${V}_${LINUX_VER}${LOCALVERSION}_armhf/boot ; ln -sf ${IMX}-usbarmory-default-${LINUX_VER}${LOCALVERSION}.dtb ${IMX}-usbarmory.dtb
 	rm linux-image-${LINUX_VER_MAJOR}-usbarmory-${V}_${LINUX_VER}${LOCALVERSION}_armhf/lib/modules/${LINUX_VER}${LOCALVERSION}/{build,source}
 	chmod 755 linux-image-${LINUX_VER_MAJOR}-usbarmory-${V}_${LINUX_VER}${LOCALVERSION}_armhf/DEBIAN
 	fakeroot dpkg-deb -b linux-image-${LINUX_VER_MAJOR}-usbarmory-${V}_${LINUX_VER}${LOCALVERSION}_armhf linux-image-${LINUX_VER_MAJOR}-usbarmory-${V}_${LINUX_VER}${LOCALVERSION}_armhf.deb


### PR DESCRIPTION
If building process fails, currently it is hard to continue the building process where
it stopped as commands does not have good defaults.

So, for example, build process if started again with same command would fail
with following error messages:
```
make[1]: Entering directory '/data/usbarmory-debian-base_image/mxs-dcp-longterm'
make -C ../linux-4.19.67 M=/data/usbarmory-debian-base_image/mxs-dcp-longterm modules_install
make[2]: Entering directory '/data/usbarmory-debian-base_image/linux-4.19.67'
  INSTALL /data/usbarmory-debian-base_image/mxs-dcp-longterm/mxs-dcp.ko
  DEPMOD  4.19.67-0
make[2]: Leaving directory '/data/usbarmory-debian-base_image/linux-4.19.67'
make[1]: Leaving directory '/data/usbarmory-debian-base_image/mxs-dcp-longterm'
cd linux-image-4.19-usbarmory-mark-two_4.19.67-0_armhf/boot ; ln -s zImage-4.19.67-0-usbarmory zImage
ln: failed to create symbolic link 'zImage': File exists
Makefile:190: recipe for target 'linux-deb' failed
make: *** [linux-deb] Error 1
```

or when unzip starts unzipping again - it stops with prompt:

```
--2019-09-06 08:40:15--  https://codeload.github.com/inversepath/mxs-dcp/zip/longterm
Resolving codeload.github.com (codeload.github.com)... 140.82.113.10
Connecting to codeload.github.com (codeload.github.com)|140.82.113.10|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [application/zip]
Saving to: 'mxs-dcp-longterm.zip'

mxs-dcp-longterm.zip                               [ <=>                                                                                                 ]  14.58K  --.-KB/s    in 0.1s

2019-09-06 08:40:16 (104 KB/s) - 'mxs-dcp-longterm.zip' saved [14933]

Archive:  mxs-dcp-longterm.zip
9280f2b3e7a66d9bac277cb21e6896b82505a4df
replace mxs-dcp-longterm/LICENSE? [y]es, [n]o, [A]ll, [N]one, [r]ename:
```

Expected behaviour would be to continue where build is left off. So, fixed it for unzip and ls.