### PR TITLE
Add notes for building in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Import the U-Boot signing GPG key:
 gpg --keyserver hkp://keys.gnupg.net --recv-keys 87F9F635D31D7652
 ```
 
+## Docker building Pre-requisites
+
+If you want to build image under Docker, you need to use --privileged option since it needs privileges for handling loop device.
+For example:
+
+```
+docker run -it --privileged --name armory debian:9
+```
+
 ## Building
 
 Launch the following command to download and build the image:


### PR DESCRIPTION
Add docker building example since docker needs "--privileged" option because of handling loop device.