### PR TITLE
Run parted with root privs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ check_version:
 
 usbarmory-${IMG_VERSION}.raw:
 	truncate -s 3500MiB usbarmory-${IMG_VERSION}.raw
-	/sbin/parted usbarmory-${IMG_VERSION}.raw --script mklabel msdos
-	/sbin/parted usbarmory-${IMG_VERSION}.raw --script mkpart primary ext4 5M 100%
+	sudo /sbin/parted usbarmory-${IMG_VERSION}.raw --script mklabel msdos
+	sudo /sbin/parted usbarmory-${IMG_VERSION}.raw --script mkpart primary ext4 5M 100%
 
 debian: check_version usbarmory-${IMG_VERSION}.raw
 	sudo /sbin/losetup /dev/loop0 usbarmory-${IMG_VERSION}.raw -o 5242880 --sizelimit 3500MiB


### PR DESCRIPTION
Otherwise it might fail by not being able to execute /usr/sbin/dmidecode