### PR TITLE
Update Docker Instructions, Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:9
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y \
+    bc binfmt-support bzip2 fakeroot gcc gcc-arm-linux-gnueabihf \
+    git gnupg make parted qemu-user-static wget xz-utils zip \
+    debootstrap sudo dirmngr bison flex libssl-dev kmod
+
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 38DBBDC86092693E \
+    && gpg --keyserver hkp://keys.gnupg.net --recv-keys 87F9F635D31D7652
+
+WORKDIR /opt/armory

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ When building the image under Docker the `--privileged` option is required to
 give privileges for handling loop devices, example:
 
 ```
-docker run -it --privileged --name armory debian:9
+docker build --rm -t armory ./
+docker run -it --privileged -v $(pwd):/opt/armory --name armory armory
 ```
 
 ## Building


### PR DESCRIPTION
Greatly simplify builds for docker users with a dependable and repeatable build environment.

I understand that Docker is controversial, especially in the security community for escape exploits.  However, this is a build repo - not a long-lived public-facing application or server application that is exposed to attackers. 

The `Dockerfile` is needed to setup a dependable and most importantly repeatable build environment.  Also it builds an environment - keeping the user from having to `apt-get install` a fresh new debian9 over and over again if they exit the container from a failed build.

Also, original README docker instructions left out a critical step to mount the local directory for builds within that `debian9` image.

So all-in-all, I've updated the README to reflect how to build, and then how to mount and run the image for a full build environment.

PS - Note that the Docker build process could greatly be simplified more with the addition of a `docker-compose.yaml` file.  But I am not sure how open you are to adding two Docker files instead of one.  The README could be simplified even further to for all commands:

    docker-compose run

PS - This will also allow us to create a C.I. pipeline here in this repo by using a Dockerfile.