### PR TITLE
Add Release Pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,16 @@
-# We are using Matrix build here on Github Actions for parallel execution.
-# We have 3 parameters: device, arch, boot
-# While the Mark II allows for 4 builds (imx6ull, imx6ul) this matrix becomes
-# an issue with the Mark One because the Makefile errors if you pass eMMC as
-# the boot parameter or imx6ull/imx6ul as the arch.
+# This workflow will build everything, package, compress, sign, hash,
+# and then upload all assets to the release.
 #
-# +----------+---------+------+------+
-# |  device  |  arch   | boot |  CI  |
-# +----------+---------+------+------+
-# | mark-one | imx53   | uSD  | PASS |
-# | mark-one | imx53   | eMMC | FAIL |
-# | mark-one | imx6ul  | uSD  | FAIL |
-# | mark-one | imx6ul  | eMMC | FAIL |
-# | mark-one | imx6ull | uSD  | FAIL |
-# | mark-one | imx6ull | eMMC | FAIL |
-# +----------+---------+------+------+
-# | mark-two | imx53   | uSD  | FAIL |
-# | mark-two | imx53   | eMMC | FAIL |
-# | mark-two | imx6ul  | uSD  | PASS |
-# | mark-two | imx6ul  | eMMC | PASS |
-# | mark-two | imx6ull | uSD  | PASS |
-# | mark-two | imx6ull | eMMC | PASS |
-# +----------+---------+------+------+
-#
-# Therefore, there are only 5 successful builds, and 7 expected failed
-# builds per the above matrix.  However, Github Actions doesn't have a clean
-# way of testing for failed builds with specific matrix params.  Therefore,
-# we need two "jobs" below.  One for mark one, and one for mark two.
+# It is triggered when you create a release.
 #
 
-name: Build-All
+name: Release
 on:
-  push:
-    branches:
-      - '*'
+  release:
+    types: [created]
 
 jobs:
+
   mark-one:
     runs-on: ubuntu-18.04
     strategy:
@@ -59,14 +35,26 @@ jobs:
         wget http://keys.inversepath.com/38DBBDC86092693E.asc && gpg --import 38DBBDC86092693E.asc
         wget http://keys.inversepath.com/87F9F635D31D7652.asc && gpg --import 87F9F635D31D7652.asc
 
-    - run: make V=${{ matrix.device }} IMX=${{ matrix.arch }} BOOT=${{ matrix.boot }} all
+    - run: make V=${{ matrix.device }} IMX=${{ matrix.arch }} BOOT=${{ matrix.boot }} release
+  
+    - name: Organize Release files to Upload
+      run: |
+        mkdir -p release/
+        rm *.raw
+        mv usbarmory* release/
+        ls -la release/
+
+    - uses: eduncan911/release-asset-action@1.0.0
+      with:
+        pattern: "release/*"
+        github-token: ${{ secrets.GITHUB_TOKEN_FOR_RELEASES }}
 
   mark-two:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
-        arch: [imx6ul, imx6ull]
+        arch: [imx6ull]
         boot: [uSD, eMMC]
         device: [mark-two]
     steps:
@@ -85,4 +73,16 @@ jobs:
         wget http://keys.inversepath.com/38DBBDC86092693E.asc && gpg --import 38DBBDC86092693E.asc
         wget http://keys.inversepath.com/87F9F635D31D7652.asc && gpg --import 87F9F635D31D7652.asc
 
-    - run: make V=${{ matrix.device }} IMX=${{ matrix.arch }} BOOT=${{ matrix.boot }} all
+    - run: make V=${{ matrix.device }} IMX=${{ matrix.arch }} BOOT=${{ matrix.boot }} release
+
+    - name: Organize Release files to Upload
+      run: |
+        mkdir -p release/
+        rm *.raw
+        mv usbarmory* release/
+        ls -la release/
+
+    - uses: eduncan911/release-asset-action@1.0.0
+      with:
+        pattern: "release/*"
+        github-token: ${{ secrets.GITHUB_TOKEN_FOR_RELEASES }}

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,14 @@ USBARMORY_REPO=https://raw.githubusercontent.com/inversepath/usbarmory/master
 MXC_SCC2_REPO=https://github.com/inversepath/mxc-scc2
 MXS_DCP_REPO=https://github.com/inversepath/mxs-dcp
 CAAM_KEYBLOB_REPO=https://github.com/inversepath/caam-keyblob
-IMG_VERSION=${V}-debian_stretch-base_image-$(shell /bin/date -u "+%Y%m%d")
+IMG_VERSION=${V}-${BOOT_PARSED}-debian_stretch-base_image-$(shell /bin/date -u "+%Y%m%d")
 LOSETUP_DEV=$(shell /sbin/losetup -f)
 
 .DEFAULT_GOAL := all
 
 V ?= mark-two
 BOOT ?= uSD
+BOOT_PARSED=$(shell echo "${BOOT}" | tr '[:upper:]' '[:lower:]')
 
 check_version:
 	@if test "${V}" = "mark-one"; then \
@@ -235,7 +236,9 @@ finalize: usbarmory-${IMG_VERSION}.raw u-boot-${UBOOT_VER}/u-boot.bin
 
 compress:
 	xz -k usbarmory-${IMG_VERSION}.raw
-	zip -j usbarmory-${IMG_VERSION}.raw.zip usbarmory-${IMG_VERSION}.raw
+
+release: check_version all compress
+	sha256sum usbarmory-${IMG_VERSION}.raw.xz > usbarmory-${IMG_VERSION}.raw.xz.sha256
 
 all: check_version linux-deb debian u-boot finalize
 
@@ -244,6 +247,6 @@ clean: check_version
 	-rm -fr u-boot-${UBOOT_VER}*
 	-rm -fr linux-image-${LINUX_VER_MAJOR}-usbarmory-${V}_${LINUX_VER}${LOCALVERSION}_armhf*
 	-rm -fr mxc-scc2-master* mxs-dcp-longterm* caam-keyblob-master*
-	-rm -f usbarmory-${V}-debian_stretch-base_image-*.raw
+	-rm -f usbarmory-${V}-${BOOT_PARSED}-debian_stretch-base_image-*.raw
 	-sudo umount -f rootfs
 	-rmdir rootfs

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ docker run -it --privileged -v $(pwd):/opt/armory --name armory armory
 
 ## Building
 
-Launch the following command to download and build the image:
+Launch the following command to download assets and build the image:
 
 ```
-# For the USB armory Mk II (external microSD)
-make all V=mark-two IMX=imx6ull BOOT=uSD
-
 # For the USB armory Mk II (internal eMMC)
 make all V=mark-two IMX=imx6ull BOOT=eMMC
+
+# For the USB armory Mk II (external microSD)
+make all V=mark-two IMX=imx6ull BOOT=uSD
 
 # For the USB armory Mk I
 make all V=mark-one IMX=imx53
@@ -51,11 +51,14 @@ make all V=mark-one IMX=imx53
 The following output files are produced:
 
 ```
-# For the USB armory Mk II
-usbarmory-mark-two-debian_stretch-base_image-YYYYMMDD.raw
+# For the USB armory Mk II (internal eMMC)
+usbarmory-mark-two-emmc-debian_stretch-base_image-YYYYMMDD.raw
+
+# For the USB armory Mk II (external microSD)
+usbarmory-mark-two-usd-debian_stretch-base_image-YYYYMMDD.raw
 
 # For the USB armory Mk I
-usbarmory-mark-one-debian_stretch-base_image-YYYYMMDD.raw
+usbarmory-mark-one-usd-debian_stretch-base_image-YYYYMMDD.raw
 ```
 
 ## Installation


### PR DESCRIPTION
A Github Action will be triggered when creating a Release that will use the new
make target to build and compress the assets.  Once successful, the
assets are uploaded to the release that triggered the action.

REQUIREMENTS:
 * create a Personal Access Token with full Repo scope permissions
 * create a GitHub Secret in the  repo named: GITHUB_TOKEN_FOR_RELEASES

Changes to code involved:

 * New make target for release
 * Renaming the assets to include the emmc or usd targets in the filename
 * Updates to README.md

A note on "already existing": The github action I am using does not exit
gracefully nor handle re-uploads - it fails the entire build.  I've forked the
action and will fix it for future revisions.